### PR TITLE
fix: keep capitalization in reference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Oetqf"
 uuid = "ba4b8404-3ddb-4226-b41e-638ed858d44e"
 authors = ["Pengcheng Shi <shipengcheng1230@gmail.com>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -58,7 +58,7 @@
 }
 
 @article{barbot2020frictional,
-  title     = {Frictional and structural controls of seismic super-cycles at the Japan trench},
+  title     = {Frictional and structural controls of seismic super-cycles at the {J}apan trench},
   volume    = {72},
   issn      = {1880-5981},
   url       = {http://dx.doi.org/10.1186/s40623-020-01185-3},
@@ -79,7 +79,7 @@
   note     = {Exported from https://app.dimensions.ai on 2019/05/05},
   number   = {1},
   pages    = {},
-  title    = {DifferentialEquations.jl – A Performant and Feature-Rich Ecosystem for Solving Differential Equations in Julia},
+  title    = {DifferentialEquations.jl – A Performant and Feature-Rich Ecosystem for Solving Differential Equations in {J}ulia},
   url      = {https://app.dimensions.ai/details/publication/pub.1085583166 and http://openresearchsoftware.metajnl.com/articles/10.5334/jors.151/galley/245/download/},
   volume   = {5},
   year     = {2017}
@@ -117,7 +117,7 @@
 
 @misc{geogreensfunctions,
   author    = {Pengcheng Shi},
-  title     = {GeoGreensFunctions, a Julia package of commonly used Green's functions for seismic and geodetic applications},
+  title     = {GeoGreensFunctions, a {J}ulia package of commonly used {G}reen's functions for seismic and geodetic applications},
   year      = {2021},
   publisher = {GitHub},
   journal   = {GitHub repository},
@@ -141,7 +141,7 @@
 
 @misc{gmshtools,
   author    = {Pengcheng Shi},
-  title     = {GmshTools, a Julia package for an easier way of using Gmsh},
+  title     = {GmshTools, a {J}ulia package for an easier way of using {G}msh},
   year      = {2021},
   publisher = {GitHub},
   journal   = {GitHub repository},
@@ -267,7 +267,7 @@
 
 @software{polanco_2023_7804590,
   author    = {Polanco, Juan Ignacio},
-  title     = {WriteVTK.jl: a Julia package for writing VTK XML
+  title     = {WriteVTK.jl: a {J}ulia package for writing VTK XML
                files
                },
   month     = apr,
@@ -319,7 +319,7 @@
 }
 
 @article{shi2020structural,
-  title     = {Structural control and system-level behavior of the seismic cycle at the Nankai Trough},
+  title     = {Structural control and system-level behavior of the seismic cycle at the {N}ankai {T}rough},
   volume    = {72},
   issn      = {1880-5981},
   url       = {http://dx.doi.org/10.1186/s40623-020-1145-0},


### PR DESCRIPTION
# Summary

Some capitalization isn't preserved unless `{}` is wrapped around them.

## Testing

No change to the code, only paper reference bib.

## Checklist

- [x] I updated documentation as needed.
- [x] I added or adjusted tests where appropriate.
- [x] I verified that CI passes locally or explained why it cannot be run.
